### PR TITLE
fix: ignore "#" comment lines in peaks files

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -160,7 +160,7 @@ def get_enrich(wildcards):
 def get_combined(wildcards):
     files = []
     if ("macs2_narrow" in PEAKTYPE) or ("macs2_broad" in PEAKTYPE):    
-        combined_m = expand(join(RESULTSDIR,"peaks","{qthresholds}","macs2","annotation","homer","{treatment_control_list}.{dupstatus}.{peak_caller_type}.annotation_qvalue.xlsx"),qthresholds=QTRESHOLDS,dupstatus=DUPSTATUS,peak_caller_type=PEAKTYPE_M,treatment_control_list=TREATMENT_LIST_M)
+        combined_m = expand(join(RESULTSDIR,"peaks","{qthresholds}","macs2","annotation","homer","{treatment_control_list}.{dupstatus}.{peak_caller_type}.annotation_qvalue.tsv"),qthresholds=QTRESHOLDS,dupstatus=DUPSTATUS,peak_caller_type=PEAKTYPE_M,treatment_control_list=TREATMENT_LIST_M)
         files.extend(combined_m)
     return files
 

--- a/workflow/rules/annotations.smk
+++ b/workflow/rules/annotations.smk
@@ -94,15 +94,15 @@ rule combine_homer:
     """
     input:
         annotation=join(RESULTSDIR,"peaks","{qthresholds}","macs2","annotation","homer","{treatment_control_list}.{dupstatus}.{peak_caller_type}.annotation.txt"),
-        xls_file = join(RESULTSDIR,"peaks","{qthresholds}","macs2","peak_output","{treatment_control_list}.{dupstatus}.{peak_caller_type}.peaks.xls")
+        peaks_file=join(RESULTSDIR,"peaks","{qthresholds}","macs2","peak_output","{treatment_control_list}.{dupstatus}.{peak_caller_type}.peaks.xls")
     output:
-        combined=join(RESULTSDIR,"peaks","{qthresholds}","macs2","annotation","homer","{treatment_control_list}.{dupstatus}.{peak_caller_type}.annotation_qvalue.xlsx")
+        combined=join(RESULTSDIR,"peaks","{qthresholds}","macs2","annotation","homer","{treatment_control_list}.{dupstatus}.{peak_caller_type}.annotation_qvalue.tsv")
     container: config['containers']['carlisle_r']
     params:
         rscript=join(SCRIPTSDIR,"_combine_macs2_homer.R")
     shell:
         """
-        Rscript {params.rscript} {input.xls_file} {input.annotation} {output.combined}
+        Rscript {params.rscript} {input.peaks_file} {input.annotation} {output.combined}
         """
 
 rule rose:

--- a/workflow/scripts/_combine_macs2_homer.R
+++ b/workflow/scripts/_combine_macs2_homer.R
@@ -1,19 +1,23 @@
 # Add peak statistics to HOMER annotations file
 
-library(openxlsx)
+library(tidyverse)
 
-args = commandArgs(trailingOnly=TRUE)
+args  <- commandArgs(trailingOnly=TRUE)
 
-peaks.file = args[1]
-homer.file = args[2]
-combined.file = args[3]
+peaks_file  <- args[1]
+homer_file  <- args[2]
+combined_file  <- args[3]
 
 # Load peak file
-peaks = read.table(peaks.file,skip = 23,header=TRUE,sep='\t',check.names = FALSE)
+# the file extension is '.xls' but it's actually just a tsv file
+peaks  <- read_tsv(peaks_file, comment = '#') %>%
+    select(c("name","fold_enrichment","-log10(qvalue)"))
 
 # Load HOMER annotations
-homer = read.table(homer.file,header=TRUE,sep='\t',check.names=FALSE,comment.char="",quote="")
+homer  <- read_tsv(homer_file) %>%
+    # rename first column to match peaks file
+    rename(name = 1)
 
 # Combine tables and write out
-combined = merge(homer,peaks[,c("name","fold_enrichment","-log10(qvalue)")],by.x=1,by.y="name")
-write.xlsx(combined,file=combined.file)
+combined <- full_join(homer, peaks, by = 'name')
+write_tsv(combined, file = combined_file)

--- a/workflow/scripts/_combine_macs2_homer.R
+++ b/workflow/scripts/_combine_macs2_homer.R
@@ -4,22 +4,24 @@ library(readr)
 library(dplyr)
 library(tidyr)
 
-args  <- commandArgs(trailingOnly=TRUE)
+args <- commandArgs(trailingOnly = TRUE)
 
-peaks_file  <- args[1]
-homer_file  <- args[2]
-combined_file  <- args[3]
+peaks_file <- args[1]
+homer_file <- args[2]
+combined_tsv <- args[3]
+combined_xlsx <- args[4]
 
 # Load peak file
 # the file extension is '.xls' but it's actually just a tsv file
-peaks  <- read_tsv(peaks_file, comment = '#') %>%
-    select(c("name","fold_enrichment","-log10(qvalue)"))
+peaks <- read_tsv(peaks_file, comment = "#") %>%
+  select(c("name", "fold_enrichment", "-log10(qvalue)"))
 
 # Load HOMER annotations
-homer  <- read_tsv(homer_file) %>%
-    # rename first column to match peaks file
-    rename(name = 1)
+homer <- read_tsv(homer_file) %>%
+  # rename first column to match peaks file
+  rename(name = 1)
 
 # Combine tables and write out
-combined <- full_join(homer, peaks, by = 'name')
-write_tsv(combined, file = combined_file)
+combined <- full_join(homer, peaks, by = "name")
+write_tsv(combined, file = combined_tsv)
+openxlsx::write.xlsx(combined, file = combined_xlsx)

--- a/workflow/scripts/_combine_macs2_homer.R
+++ b/workflow/scripts/_combine_macs2_homer.R
@@ -1,6 +1,8 @@
 # Add peak statistics to HOMER annotations file
 
-library(tidyverse)
+library(readr)
+library(dplyr)
+library(tidyr)
 
 args  <- commandArgs(trailingOnly=TRUE)
 


### PR DESCRIPTION
## Changes

- Rather than set a fixed number of lines to skip (which may change, and was off by one for my test run), ignore all lines that start with '#' as the comment character.
- Refactor the combine_homer Rscript to use the tidyverse.
- Output tsv ~instead of~ in addition to excel format.

## Issues

https://github.com/CCBR/CARLISLE/pull/132

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~
